### PR TITLE
Main functionality of CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## v1.1.0 (09/08/2018)
+*No changelog for this release.*

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -139,8 +139,11 @@ spec:
 
             post {
                 failure {
-                    k8sDeleteBeta(params.project)
-                    currentBuild.result = 'SUCCESS'
+                    script{
+                        k8sDeleteBeta(params.project)
+                        currentBuild.result = 'SUCCESS'
+                    }
+
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -129,6 +129,23 @@ spec:
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
                         env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
+
+//                        ######### untested for now  #########
+
+//                        container("helm") {
+//                            k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
+//                        }
+//                        container("helm") {
+//                            ciK8sUpgrade(props.project, props.addr, "${project}-uat")
+//                        }
+//                        container("kubectl") {
+//                            ciK8sRollout(props.project, "${project}-uat")
+//                        }
+//                        container("golang") {
+//                            k8sUatTestGolang(props.addr)
+//                        }
+//                       ##################
+
                         //docker tag
                         container('docker') {
                             ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -136,9 +136,8 @@ spec:
                         ciDeleteAfterTimingOut(10, 'MINUTES') {
 
                             ciConditionalInputExecution("Deploy Gate",
-                                    "Deploy ${params.project} to UAT?",
-                                    "ok", "deploy2uat") {
-
+                                    "Release ${params.project} ?",
+                                    "ok", "release") {
                                 //docker tag
                                 container('docker') {
                                     ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])
@@ -147,7 +146,7 @@ spec:
                                 //git tag
                                 container('git') {
                                     ciWithGitKey(params.rsaKey) {
-                                        ciTagGitRelease(env.RELEASE_TAG)
+                                        ciTagGitRelease(tag: env.RELEASE_TAG)
                                     }
                                 }
 
@@ -158,20 +157,8 @@ spec:
                                     }
                                 }
 
-// my local cm is in a bad state :)
-//                              container("helm") {
-//                                  k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
-//                              }
-
-
                                 container("helm") {
-                                    ciK8sUpgrade(params.project, params.uatAddr, "${params.project}-uat", env.RELEASE_TAG)
-                                }
-                                container("kubectl") {
-                                    ciK8sRollout(params.project, "${project}-uat")
-                                }
-                                container("golang") {
-                                    k8sProdTestGolang(params.uatAddr)
+                                    ciK8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
                                 }
                             }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -58,6 +58,10 @@ spec:
         string(name: 'addr', defaultValue: 'go-demo-3.10.64.108.181.nip.io')
         string(name: 'cmAddr', defaultValue: 'cm.4.10.64.108.181.nip.io')
         string(name: 'chartVer', defaultValue: '0.0.1')
+
+        // new
+        string(name: 'rsaKey', defaultValue: 'TM_RSA')
+        string(name: 'githubToken', defaultValue: 'GITHUB_TOKEN')
     }
 
     options {
@@ -72,7 +76,7 @@ spec:
                 ciPrettyBuildNumber()
 
                 container('git') {
-                    ciWithGitKey('TM_RSA') {
+                    ciWithGitKey(params.rsaKey) {
                         ciBuildEnvVars()
                     }
                 }
@@ -109,7 +113,7 @@ spec:
         }
 
 
-        stage("deploy2uat") {
+        stage("Release & Deploy") {
             when {
                 anyOf {
                     branch "master"
@@ -120,7 +124,7 @@ spec:
             steps {
                 script {
                     container("git") {
-                        ciWithGitKey('TM_RSA') {
+                        ciWithGitKey(params.rsaKey) {
                             env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
                         }
                     }
@@ -142,14 +146,14 @@ spec:
 
                                 //git tag
                                 container('git') {
-                                    ciWithGitKey('TM_RSA') {
+                                    ciWithGitKey(params.rsaKey) {
                                         ciTagGitRelease(env.RELEASE_TAG)
                                     }
                                 }
 
                                 container('gren') {
                                     //https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
-                                    withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
+                                    withCredentials([string(credentialsId: params.githubToken, variable: 'TOKEN')]) {
                                         sh "gren release --token=${TOKEN}"
                                     }
                                 }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -134,8 +134,8 @@ spec:
                 script {
                     timeout(time: 10, unit: 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
-
                         sh "DEPLOYED TO UAT"
+                        sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT} -m \"Message here\""
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -56,6 +56,7 @@ spec:
         string(name: 'image', defaultValue: 'digitalinside/go-demo-3')
         string(name: 'domain', defaultValue: '10.64.108.181.nip.io')
         string(name: 'addr', defaultValue: 'go-demo-3.10.64.108.181.nip.io')
+        string(name: 'uatAddr', defaultValue: 'uat.go-demo-3.10.64.108.181.nip.io')
         string(name: 'cmAddr', defaultValue: 'cm.4.10.64.108.181.nip.io')
         string(name: 'chartVer', defaultValue: '0.0.1')
 
@@ -137,7 +138,6 @@ spec:
                             ciConditionalInputExecution("Deploy Gate",
                                     "Deploy ${params.project} to UAT?",
                                     "ok", "deploy2uat") {
-                                //todo deployment code missing
 
                                 //docker tag
                                 container('docker') {
@@ -156,6 +156,21 @@ spec:
                                     withCredentials([string(credentialsId: params.githubToken, variable: 'TOKEN')]) {
                                         sh "gren release --token=${TOKEN}"
                                     }
+                                }
+
+//                              container("helm") {
+//                                  k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
+//                              }
+
+
+                                container("helm") {
+                                    ciK8sUpgrade(props.project, params.uatAddr, "${project}-uat", env.BUILD_TAG)
+                                }
+                                container("kubectl") {
+                                    ciK8sRollout(params.project, "${project}-uat")
+                                }
+                                container("golang") {
+                                    k8sProdTestGolang(params.uatAddr)
                                 }
                             }
 
@@ -194,16 +209,6 @@ spec:
 //todo
 //                        ######### untested for now  #########
 
-//                        container("helm") {
-//                            k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
-//                        }
-//                        container("helm") {
-//                            ciK8sUpgrade(props.project, props.addr, "${project}-uat")
-//                        }
-//                        container("kubectl") {
-//                            ciK8sRollout(props.project, "${project}-uat")
-//                        }
-//                        container("golang") {
-//                            k8sUatTestGolang(props.addr)
-//                        }
+
+
 //                       ##################

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -48,7 +48,7 @@ spec:
 
     parameters {
         string(name: 'project', defaultValue: 'go-demo-3')
-        string(name: 'image', defaultValue: 'digitalinside/go-demo-4')
+        string(name: 'image', defaultValue: 'digitalinside/go-demo-3')
         string(name: 'domain', defaultValue: '10.217.32.221.nip.io')
         string(name: 'addr', defaultValue: 'go-demo-4.10.217.32.221.nip.io')
         string(name: 'cmAddr', defaultValue: 'cm.4.10.217.32.221.nip.io')

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -163,19 +163,9 @@ spec:
             }
         }
 
-        stage("clean up") {
-            when {
-                not {
-                    anyOf {
-                        branch "master"
-                        branch "hotfix-*"
-                    }
-                }
-            }
-
-            steps {
-                script {
-
+        post {
+            always {
+                ciWhenNotReleaseBranches {
                     container("helm") {
                         // this will delete feature branch deployments, unless someone wants to keep it running
                         // later it should be deleted manually, or with PR merge hook
@@ -190,9 +180,7 @@ spec:
 
                         }
                     }
-
                 }
-
             }
         }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -66,6 +66,7 @@ spec:
         stage("prep") {
             steps {
                 script {
+                    //https://issues.jenkins-ci.org/browse/JENKINS-52623 i found issue and waiting it to be fixed, i think carlos is on it now
                     env.GIT_COMMIT = sh (script: """ git rev-parse HEAD """, returnStdout: true).trim()
                     env.shortGitCommit = "${env.GIT_COMMIT[0..10]}"
                     currentBuild.displayName = new SimpleDateFormat("yy.MM.dd").format(new Date()) + "-" + env.BUILD_NUMBER
@@ -78,7 +79,7 @@ spec:
             steps {
                 container('git') {
                     script {
-                        env.BUILD_TAG = ciVersionRead()
+                        env.BUILD_TAG = ciBuildVersionRead()
                         echo "build tag set to: ${env.BUILD_TAG}"
                     }
                 }
@@ -112,28 +113,24 @@ spec:
             }
         }
 
-        stage ("latest master tags") {
-            when {
-                branch "master"
-            }
-
-            steps {
-                container('docker') {
-                    ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}"])
-                }
-            }
-        }
-
 
         stage ("deploy2uat") {
             when {
-                branch "master"
+                anyOf {
+                    branch "master"
+                    branch "hotfix-*"
+                }
             }
 
             steps {
                 script {
                     timeout(time: 10, unit: 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+
+                        container('docker') {
+                            ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", ciVersionRead() ])
+                        }
+
                         tagGitRelease(env.BUILD_TAG)
                     }
                 }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -79,8 +79,13 @@ spec:
 
         stage('build') {
             steps {
+                container('git') {
+                    script {
+                        env.BUILD_TAG = ciVersionRead()
+                    }
+                }
                 container('docker') {
-                    ciK8sBuildImage(params.image, false, [env.shortGitCommit])
+                    ciK8sBuildImage(params.image, false, env.BUILD_TAG, [env.shortGitCommit])
                 }
             }
         }
@@ -88,7 +93,7 @@ spec:
         stage("func-test") {
             steps {
                 container("helm") {
-                    ciK8sUpgradeBeta(params.project, params.domain)
+                    ciK8sUpgradeBeta(params.project, params.domain, env.BUILD_TAG)
                 }
 
                 container("kubectl") {
@@ -96,7 +101,7 @@ spec:
                 }
 
                 container("golang") {
-                    ciK8sFuncTestGolang(params.project, params.domain)
+                    k8sFuncTestGolang(params.project, params.domain)
                 }
             }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -71,7 +71,7 @@ spec:
         stage('build') {
             steps {
                 container('docker') {
-                    k8sBuildImageBeta(props.image)
+                    ciK8sBuildImage(props.image)
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -113,7 +113,7 @@ spec:
         }
 
 
-        stage("Release & Deploy") {
+        stage("Release") {
             when {
                 anyOf {
                     branch "master"
@@ -134,7 +134,7 @@ spec:
                         // better to autodelete the deployment when it times out
                         ciDeleteAfterTimingOut(10, 'MINUTES') {
 
-                            ciConditionalInputExecution("Deploy Gate",
+                            ciConditionalInputExecution("Release Gate",
                                     "Release ${params.project} ?",
                                     "ok", "release") {
                                 //docker tag

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -124,20 +124,8 @@ spec:
             }
         }
 
-        stage ("latest master tags") {
-            when {
-                branch "master"
-            }
 
-            steps {
-                container('docker') {
-                    ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}"])
-                }
-            }
-        }
-
-
-        stage ("deploy/no-deploy") {
+        stage ("deploy2uat") {
             when {
                 branch "master"
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -80,7 +80,7 @@ spec:
         stage('build') {
             steps {
                 container('docker') {
-                    ciK8sBuildImage(params.image)
+                    ciK8sBuildImage(params.image, false)
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -184,7 +184,7 @@ spec:
 
                     // this will delete feature branch deployments, unless someone wants to keep it running
                     // later it should be deleted manually, or with PR merge hook
-                    ciDeleteAfterTimingOut(2, 'MINUTES') {
+                    ciDeleteAfterTimingOut(1, 'MINUTES') {
                         env.userInput = input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
                     }
                 }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -105,7 +105,9 @@ spec:
 
             post {
                 failure {
-                    k8sDeleteBeta(params.project)
+                    container("helm") {
+                        k8sDeleteBeta(params.project)
+                    }
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -103,7 +103,7 @@ spec:
             post {
                 always {
                     container("helm") {
-                        k8sDeleteBeta(props.project)
+                        k8sDeleteBeta(params.project)
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -124,11 +124,11 @@ spec:
                         }
                     }
 
-                    // you can have your master builds running for some time until someone decides to promote it.
-                    // better to autodelete the deployment when it times out
-                    ciDeleteAfterTimingOut(2, 'MINUTES') {
-                        env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project} to UAT?", ok: 'Deploy')
-
+                    container("helm") {
+                        // you can have your master builds running for some time until someone decides to promote it.
+                        // better to autodelete the deployment when it times out
+                        ciDeleteAfterTimingOut(2, 'MINUTES') {
+                            env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project} to UAT?", ok: 'Deploy')
 
 //                        ######### untested for now  #########
 
@@ -146,25 +146,27 @@ spec:
 //                        }
 //                       ##################
 
-                        //docker tag
-                        container('docker') {
-                            ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])
-                        }
-
-                        //git tag
-                        container('git') {
-                            ciWithGitKey('TM_RSA') {
-                                ciTagGitRelease(env.RELEASE_TAG)
+                            //docker tag
+                            container('docker') {
+                                ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])
                             }
-                        }
 
-                        container('gren') {
-                            //https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
-                            withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
-                                sh "gren release --token=${TOKEN}"
+                            //git tag
+                            container('git') {
+                                ciWithGitKey('TM_RSA') {
+                                    ciTagGitRelease(env.RELEASE_TAG)
+                                }
+                            }
+
+                            container('gren') {
+                                //https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+                                withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
+                                    sh "gren release --token=${TOKEN}"
+                                }
                             }
                         }
                     }
+
                 }
             }
         }
@@ -182,12 +184,15 @@ spec:
             steps {
                 script {
 
-                    // this will delete feature branch deployments, unless someone wants to keep it running
-                    // later it should be deleted manually, or with PR merge hook
-                    ciDeleteAfterTimingOut(1, 'MINUTES') {
-                        env.userInput = input(id: "delete deployment", message: "Delete ${env.BRANCH_NAME} deployment?", ok: 'Delete')
-                        ciK8sDeleteBeta(params.project)
+                    container("helm") {
+                        // this will delete feature branch deployments, unless someone wants to keep it running
+                        // later it should be deleted manually, or with PR merge hook
+                        ciDeleteAfterTimingOut(1, 'MINUTES') {
+                            env.userInput = input(id: "delete deployment", message: "Delete ${env.BRANCH_NAME} deployment?", ok: 'Delete')
+                            ciK8sDeleteBeta(params.project)
+                        }
                     }
+
                 }
 
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -158,6 +158,7 @@ spec:
                                     }
                                 }
 
+// my local cm is in a bad state :)
 //                              container("helm") {
 //                                  k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
 //                              }
@@ -204,11 +205,3 @@ spec:
         }
     }
 }
-
-
-//todo
-//                        ######### untested for now  #########
-
-
-
-//                       ##################

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -127,7 +127,7 @@ spec:
                     // you can have your master builds running for some time until someone decides to promote it.
                     // better to autodelete the deployment when it times out
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
-                        env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+                        env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project} to UAT?", ok: 'Deploy')
 
 
 //                        ######### untested for now  #########
@@ -185,7 +185,8 @@ spec:
                     // this will delete feature branch deployments, unless someone wants to keep it running
                     // later it should be deleted manually, or with PR merge hook
                     ciDeleteAfterTimingOut(1, 'MINUTES') {
-                        env.userInput = input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
+                        env.userInput = input(id: "delete deployment", message: "Delete ${env.BRANCH_NAME} deployment?", ok: 'Delete')
+                        ciK8sDeleteBeta(params.project)
                     }
                 }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -61,6 +61,7 @@ spec:
     }
 
     options {
+        disableConcurrentBuilds()
         timeout(time: 45, unit: 'MINUTES')
     }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -84,5 +84,29 @@ spec:
                 }
             }
         }
+
+        stage("func-test") {
+            steps {
+                container("helm") {
+                    ciK8sUpgradeBeta(params.project, params.domain)
+                }
+
+                container("kubectl") {
+                    k8sRolloutBeta(params.project)
+                }
+
+                container("golang") {
+                    ciK8sFuncTestGolang(params.project, params.domain)
+                }
+            }
+
+            post {
+                always {
+                    container("helm") {
+                        k8sDeleteBeta(props.project)
+                    }
+                }
+            }
+        }
     }
 }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -133,7 +133,7 @@ spec:
                     container("helm") {
                         // you can have your master builds running for some time until someone decides to promote it.
                         // better to autodelete the deployment when it times out
-                        ciDeleteAfterTimingOut(2, 'MINUTES') {
+                        ciDeleteAfterTimingOut(10, 'MINUTES') {
 
                             ciConditionalInputExecution("Deploy Gate",
                                     "Deploy ${params.project} to UAT?",

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -125,7 +125,7 @@ spec:
                     }
 
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
-                        input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+                        env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
                         //docker tag
                         container('docker') {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -134,8 +134,14 @@ spec:
                 script {
                     timeout(time: 10, unit: 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+
                         echo "DEPLOYED TO UAT"
+
+                        sh """ git config --global user.email "tigran@mna.com" """
+                        git """config --global user.name "Tigran Mna" """
+
                         sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT} -m \"Message here\""
+                        sh "git push --tags origin master"
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -140,7 +140,7 @@ spec:
 
                             //git tag
                             container('git') {
-                                tagGitRelease(env.RELEASE_TAG)
+                                ciTagGitRelease(env.RELEASE_TAG)
                             }
                         }
                     }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -128,42 +128,31 @@ spec:
                         // you can have your master builds running for some time until someone decides to promote it.
                         // better to autodelete the deployment when it times out
                         ciDeleteAfterTimingOut(2, 'MINUTES') {
-                            env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project} to UAT?", ok: 'Deploy')
 
-//                        ######### untested for now  #########
+                            ciConditionalInputExecution("Deploy Gate", "Deploy ${params.project} to UAT?", "ok", "deploy2uat") {
+                                //todo deployment code missing
 
-//                        container("helm") {
-//                            k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
-//                        }
-//                        container("helm") {
-//                            ciK8sUpgrade(props.project, props.addr, "${project}-uat")
-//                        }
-//                        container("kubectl") {
-//                            ciK8sRollout(props.project, "${project}-uat")
-//                        }
-//                        container("golang") {
-//                            k8sUatTestGolang(props.addr)
-//                        }
-//                       ##################
+                                //docker tag
+                                container('docker') {
+                                    ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])
+                                }
 
-                            //docker tag
-                            container('docker') {
-                                ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])
-                            }
+                                //git tag
+                                container('git') {
+                                    ciWithGitKey('TM_RSA') {
+                                        ciTagGitRelease(env.RELEASE_TAG)
+                                    }
+                                }
 
-                            //git tag
-                            container('git') {
-                                ciWithGitKey('TM_RSA') {
-                                    ciTagGitRelease(env.RELEASE_TAG)
+                                container('gren') {
+                                    //https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
+                                    withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
+                                        sh "gren release --token=${TOKEN}"
+                                    }
                                 }
                             }
 
-                            container('gren') {
-                                //https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
-                                withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
-                                    sh "gren release --token=${TOKEN}"
-                                }
-                            }
+
                         }
                     }
 
@@ -188,8 +177,11 @@ spec:
                         // this will delete feature branch deployments, unless someone wants to keep it running
                         // later it should be deleted manually, or with PR merge hook
                         ciDeleteAfterTimingOut(1, 'MINUTES') {
-                            env.userInput = input(id: "delete deployment", message: "Delete ${env.BRANCH_NAME} deployment?", ok: 'Delete')
-                            ciK8sDeleteBeta(params.project)
+
+                            ciConditionalInputExecution("delete feature", "delete feature deployment?", "continue", "delete deployment") {
+                                ciK8sDeleteBeta(params.project)
+                            }
+
                         }
                     }
 
@@ -200,3 +192,21 @@ spec:
 
     }
 }
+
+
+//todo
+//                        ######### untested for now  #########
+
+//                        container("helm") {
+//                            k8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
+//                        }
+//                        container("helm") {
+//                            ciK8sUpgrade(props.project, props.addr, "${project}-uat")
+//                        }
+//                        container("kubectl") {
+//                            ciK8sRollout(props.project, "${project}-uat")
+//                        }
+//                        container("golang") {
+//                            k8sUatTestGolang(props.addr)
+//                        }
+//                       ##################

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -162,28 +162,27 @@ spec:
                 }
             }
         }
+    }
 
-        post {
-            always {
-                ciWhenNotReleaseBranches {
-                    container("helm") {
-                        // this will delete feature branch deployments, unless someone wants to keep it running
-                        // later it should be deleted manually, or with PR merge hook
-                        ciDeleteAfterTimingOut(1, 'MINUTES') {
+    post {
+        always {
+            ciWhenNotReleaseBranches {
+                container("helm") {
+                    // this will delete feature branch deployments, unless someone wants to keep it running
+                    // later it should be deleted manually, or with PR merge hook
+                    ciDeleteAfterTimingOut(1, 'MINUTES') {
 
-                            ciConditionalInputExecution("delete feature",
-                                    "delete feature deployment?",
-                                    "continue",
-                                    "delete deployment") {
-                                ciK8sDeleteBeta(params.project)
-                            }
-
+                        ciConditionalInputExecution("delete feature",
+                                "delete feature deployment?",
+                                "continue",
+                                "delete deployment") {
+                            ciK8sDeleteBeta(params.project)
                         }
+
                     }
                 }
             }
         }
-
     }
 }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -73,7 +73,7 @@ spec:
                 script {
                     //https://issues.jenkins-ci.org/browse/JENKINS-52623 i found issue and waiting it to be fixed, i think carlos is on it now
                     container('git') {
-                        env.GIT_COMMIT = sh (script: """ git rev-parse HEAD """, returnStdout: true).trim()
+                        env.GIT_COMMIT = sh(script: """ git rev-parse HEAD """, returnStdout: true).trim()
                         env.shortGitCommit = "${env.GIT_COMMIT[0..10]}"
                         env.BUILD_TAG = ciBuildVersionRead()
                         echo "build tag set to: ${env.BUILD_TAG}"
@@ -119,7 +119,7 @@ spec:
         }
 
 
-        stage ("deploy2uat") {
+        stage("deploy2uat") {
             when {
                 anyOf {
                     branch "master"
@@ -129,14 +129,16 @@ spec:
 
             steps {
                 script {
-                    env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
+                    container("git") {
+                        env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
+                    }
 
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
                         //docker tag
                         container('docker') {
-                            ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG ])
+                            ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG])
                         }
 
                         //git tag
@@ -148,14 +150,13 @@ spec:
                             withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
                                 sh "gren release --token=${TOKEN}"
                             }
-
                         }
                     }
                 }
             }
         }
 
-        stage ("clean up") {
+        stage("clean up") {
             when {
                 not {
                     anyOf {
@@ -174,7 +175,7 @@ spec:
                             echo "remember to delete resources "
                             echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
                         }
-                    } catch(err) {
+                    } catch (err) {
                         container('helm') {
                             k8sDeleteBeta(params.project)
                         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -133,7 +133,7 @@ spec:
             steps {
                 timeout(time: 1, unit: 'MINUTES') {
                     input message: "Keep deployment alive ?"
-                    eecho "remember to delete resources"
+                    echo "remember to delete resources"
                 }
             }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -157,7 +157,7 @@ spec:
                                 }
 
                                 container("helm") {
-                                    ciK8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
+                                    ciK8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr, true)
                                 }
                             }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -80,7 +80,7 @@ spec:
         stage('build') {
             steps {
                 container('docker') {
-                    ciK8sBuildImage(params.image, false)
+                    ciK8sBuildImage(params.image, false, [env.shortGitCommit])
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
   - name: helm
-    image: vfarcic/helm:2.8.2
+    image: vfarcic/helm:2.9.1
     command:
     - cat
     tty: true

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -117,6 +117,7 @@ spec:
             when {
                 anyOf {
                     branch "master"
+                    branch "deployment"
                     branch "hotfix-*"
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -28,6 +28,11 @@ spec:
     command:
     - cat
     tty: true
+  - name: git
+    image: digitalinside/gren:latest
+    command:
+    - cat
+    tty: true    
   - name: kubectl
     image: vfarcic/kubectl
     command: ["cat"]

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -54,11 +54,10 @@ spec:
     parameters {
         string(name: 'project', defaultValue: 'go-demo-3')
         string(name: 'image', defaultValue: 'digitalinside/go-demo-3')
-        string(name: 'domain', defaultValue: '10.64.108.181.nip.io')
-        string(name: 'addr', defaultValue: 'go-demo-3.10.64.108.181.nip.io')
-        string(name: 'uatAddr', defaultValue: 'uat.go-demo-3.10.64.108.181.nip.io')
-        string(name: 'cmAddr', defaultValue: 'cm.4.10.64.108.181.nip.io')
-        string(name: 'chartVer', defaultValue: '0.0.1')
+        string(name: 'domain', defaultValue: '192.168.0.10.nip.io')
+        string(name: 'addr', defaultValue: 'go-demo-3.192.168.0.10.nip.io')
+        string(name: 'uatAddr', defaultValue: 'uat.go-demo-3.192.168.0.10.nip.io')
+        string(name: 'cmAddr', defaultValue: 'cm.4.192.168.0.10.nip.io')
 
         // new
         string(name: 'rsaKey', defaultValue: 'TM_RSA')
@@ -161,7 +160,6 @@ spec:
                                     ciK8sPushHelm(params.project, env.RELEASE_TAG, params.cmAddr)
                                 }
                             }
-
 
                         }
                     }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -54,9 +54,9 @@ spec:
     parameters {
         string(name: 'project', defaultValue: 'go-demo-3')
         string(name: 'image', defaultValue: 'digitalinside/go-demo-3')
-        string(name: 'domain', defaultValue: '192.168.0.10.nip.io')
-        string(name: 'addr', defaultValue: 'go-demo-3.192.168.0.10.nip.io')
-        string(name: 'cmAddr', defaultValue: 'cm.4.192.168.0.10.nip.io')
+        string(name: 'domain', defaultValue: '10.64.108.181.nip.io')
+        string(name: 'addr', defaultValue: 'go-demo-3.10.64.108.181.nip.io')
+        string(name: 'cmAddr', defaultValue: 'cm.4.10.64.108.181.nip.io')
         string(name: 'chartVer', defaultValue: '0.0.1')
     }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -117,7 +117,6 @@ spec:
             when {
                 anyOf {
                     branch "master"
-                    branch "deployment"
                     branch "hotfix-*"
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -29,6 +29,10 @@ spec:
     command:
     - cat
     tty: true
+  - name: kubectl
+    image: vfarcic/kubectl
+    command: ["cat"]
+    tty: true
   - name: docker
     image: docker
     command:

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -141,6 +141,7 @@ spec:
                         timeout(time: 1, unit: 'MINUTES') {
                             input message: "Keep deployment alive ?"
                             echo "remember to delete resources"
+                            echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
                         }
                     } catch(err) {
                         k8sDeleteBeta(params.project)

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -85,7 +85,7 @@ spec:
                     }
                 }
                 container('docker') {
-                    ciK8sBuildImage(params.image, false, env.BUILD_TAG, [env.shortGitCommit])
+                    ciK8sBuildImage(params.image, false, env.BUILD_TAG)
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -134,14 +134,19 @@ spec:
                 script {
                     timeout(time: 10, unit: 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+                        withCredentials([sshUserPrivateKey(credentialsId: 'TM_RSA', keyFileVariable: 'SSH_KEY')]) {
+                            sh 'echo ssh -i $SSH_KEY -l git -o StrictHostKeyChecking=no \\"\\$@\\" > local_ssh.sh'
+                            sh 'chmod +x local_ssh.sh'
+                            withEnv(['GIT_SSH=local_ssh.sh']) {
 
-                        echo "DEPLOYED TO UAT"
+                                //ugly, but could not make it work globally... jenkins sometimes makes me hate my life
+                                sh """ git config --global user.email "tigran@mna.com" """
+                                sh """ git config --global user.name "Tigran Mna" """
 
-                        sh """ git config --global user.email "tigran@mna.com" """
-                        sh """ git config --global user.name "Tigran Mna" """
-
-                        sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT} -m \"Message here\""
-                        sh "git push origin ${env.BUILD_TAG} "
+                                sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT}"
+                                sh "git push origin ${env.BUILD_TAG} "
+                            }
+                        }
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -53,20 +53,14 @@ spec:
     parameters {
         string(name: 'project', defaultValue: 'go-demo-3')
         string(name: 'image', defaultValue: 'digitalinside/go-demo-3')
-        string(name: 'domain', defaultValue: '10.217.32.221.nip.io')
-        string(name: 'addr', defaultValue: 'go-demo-4.10.217.32.221.nip.io')
-        string(name: 'cmAddr', defaultValue: 'cm.4.10.217.32.221.nip.io')
+        string(name: 'domain', defaultValue: '192.168.0.10.nip.io')
+        string(name: 'addr', defaultValue: 'go-demo-3.192.168.0.10.nip.io')
+        string(name: 'cmAddr', defaultValue: 'cm.4.192.168.0.10.nip.io')
         string(name: 'chartVer', defaultValue: '0.0.1')
     }
 
     options {
         timeout(time: 45, unit: 'MINUTES')
-    }
-
-    environment {
-        GH_USER="tigran10" // Replace me
-        DH_USER="digitalinside" // Replace me
-        PROJECT="go-demo-4"
     }
 
     stages {
@@ -102,21 +96,53 @@ spec:
                 }
 
                 container("kubectl") {
-                    k8sRolloutBeta(params.project)
+                    echo "rollout"
+//                    k8sRolloutBeta(params.project)
                 }
 
                 container("golang") {
-                    k8sFuncTestGolang(params.project, params.domain)
+                    echo "func tests"
+//                    k8sFuncTestGolang(params.project, params.domain)
+                }
+            }
+
+        }
+
+        stage ("latest master tag") {
+            when {
+                branch "master"
+            }
+
+            steps {
+                container('docker') {
+                    ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}"])
+                }
+            }
+        }
+
+        stage ("clean up") {
+            when {
+                not {
+                    anyOf {
+                        branch "master"
+                        branch "hotfix-*"
+                    }
+                }
+            }
+
+            steps {
+                timeout(time: 1, unit: 'MINUTES') {
+                    input message: "Keep deployment alive ?"
+                    eecho "remember to delete resources"
                 }
             }
 
             post {
-                always {
-                    container("helm") {
-                        k8sDeleteBeta(params.project)
-                    }
+                failure {
+                    k8sDeleteBeta(params.project)
                 }
             }
         }
+
     }
 }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -1,6 +1,3 @@
-import java.text.SimpleDateFormat
-
-
 pipeline {
     agent {
         kubernetes {
@@ -74,7 +71,9 @@ spec:
                 ciPrettyBuildNumber()
 
                 container('git') {
-                    ciBuildEnvVars()
+                    ciWithGitKey('TM_RSA') {
+                        ciBuildEnvVars()
+                    }
                 }
 
                 container('docker') {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -185,12 +185,7 @@ spec:
                     // this will delete feature branch deployments, unless someone wants to keep it running
                     // later it should be deleted manually, or with PR merge hook
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
-                        env.userInput = // change to a convenient timeout for you
-                                timeout(time: 1, unit: 'MINUTES') {
-                                    input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
-                                    echo "remember to delete resources later: run the command below"
-                                    echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
-                                }
+                        env.userInput = input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
                     }
                 }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -141,7 +141,7 @@ spec:
                         sh """ git config --global user.name "Tigran Mna" """
 
                         sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT} -m \"Message here\""
-                        sh "git push --tags origin master"
+                        sh "git push origin ${env.BUILD_TAG} "
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -57,7 +57,7 @@ spec:
         string(name: 'domain', defaultValue: '192.168.0.10.nip.io')
         string(name: 'addr', defaultValue: 'go-demo-3.192.168.0.10.nip.io')
         string(name: 'uatAddr', defaultValue: 'uat.go-demo-3.192.168.0.10.nip.io')
-        string(name: 'cmAddr', defaultValue: 'cm.4.192.168.0.10.nip.io')
+        string(name: 'cmAddr', defaultValue: 'cm.192.168.0.10.nip.io')
 
         // new
         string(name: 'rsaKey', defaultValue: 'TM_RSA')

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -28,7 +28,7 @@ spec:
     command:
     - cat
     tty: true
-  - name: git
+  - name: gren
     image: digitalinside/gren:latest
     command:
     - cat
@@ -146,6 +146,13 @@ spec:
                             //git tag
                             container('git') {
                                 ciTagGitRelease(env.RELEASE_TAG)
+                            }
+
+                            container('gren') {
+                                withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
+                                    sh "gren release --token=${TOKEN}"
+                                }
+
                             }
                         }
                     }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -19,10 +19,9 @@ spec:
     command:
     - cat
     tty: true
-  - name: go
-    image: golang:1.10
-    command:
-    - cat
+  - name: golang
+    image: golang:1.9
+    command: ["cat"]
     tty: true
   - name: git
     image: alpine/git

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -103,6 +103,11 @@ spec:
                 }
             }
 
+            post {
+                failure {
+                    k8sDeleteBeta(params.project)
+                }
+            }
         }
 
         stage ("latest master tag") {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -68,25 +68,15 @@ spec:
     }
 
     stages {
-        stage("prep") {
-            steps {
-                script {
-                    //https://issues.jenkins-ci.org/browse/JENKINS-52623 i found issue and waiting it to be fixed, i think carlos is on it now
-                    container('git') {
-                        env.GIT_COMMIT = sh(script: """ git rev-parse HEAD """, returnStdout: true).trim()
-                        env.shortGitCommit = "${env.GIT_COMMIT[0..10]}"
-                        env.BUILD_TAG = ciBuildVersionRead()
-                        echo "build tag set to: ${env.BUILD_TAG}"
-                    }
-
-                    currentBuild.displayName = new SimpleDateFormat("yy.MM.dd").format(new Date()) + "-" + env.BUILD_NUMBER
-                }
-            }
-        }
-
 
         stage('build') {
             steps {
+                ciPrettyBuildNumber()
+
+                container('git') {
+                    ciBuildEnvVars()
+                }
+
                 container('docker') {
                     //for feature branch
                     ciK8sBuildImage(params.image, false, env.BUILD_TAG)
@@ -147,6 +137,7 @@ spec:
                         }
 
                         container('gren') {
+                            //https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/
                             withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
                                 sh "gren release --token=${TOKEN}"
                             }
@@ -172,7 +163,7 @@ spec:
                         // change to a convenient timeout for you
                         timeout(time: 1, unit: 'MINUTES') {
                             input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
-                            echo "remember to delete resources "
+                            echo "remember to delete resources: run the command below"
                             echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
                         }
                     } catch (err) {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -164,7 +164,7 @@ spec:
 
 
                                 container("helm") {
-                                    ciK8sUpgrade(props.project, params.uatAddr, "${project}-uat", env.BUILD_TAG)
+                                    ciK8sUpgrade(props.project, params.uatAddr, "${project}-uat", env.RELEASE_TAG)
                                 }
                                 container("kubectl") {
                                     ciK8sRollout(params.project, "${project}-uat")

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -164,7 +164,7 @@ spec:
 
 
                                 container("helm") {
-                                    ciK8sUpgrade(props.project, params.uatAddr, "${project}-uat", env.RELEASE_TAG)
+                                    ciK8sUpgrade(params.project, params.uatAddr, "${params.project}-uat", env.RELEASE_TAG)
                                 }
                                 container("kubectl") {
                                     ciK8sRollout(params.project, "${project}-uat")

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -47,7 +47,7 @@ spec:
     }
 
     parameters {
-        string(name: 'project', defaultValue: 'go-demo-4')
+        string(name: 'project', defaultValue: 'go-demo-3')
         string(name: 'image', defaultValue: 'digitalinside/go-demo-4')
         string(name: 'domain', defaultValue: '10.217.32.221.nip.io')
         string(name: 'addr', defaultValue: 'go-demo-4.10.217.32.221.nip.io')

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -129,40 +129,28 @@ spec:
 
             steps {
                 script {
-                    try {
+                    env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
 
-                        //agree on release tag
-                        env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
+                    ciDeleteAfterTimingOut(2, 'MINUTES') {
+                        input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
-                        timeout(time: 2, unit: 'MINUTES') {
-                            input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+                        //docker tag
+                        container('docker') {
+                            ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG ])
+                        }
 
+                        //git tag
+                        container('git') {
+                            ciTagGitRelease(env.RELEASE_TAG)
+                        }
 
-                            //docker tag
-                            container('docker') {
-                                ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG ])
+                        container('gren') {
+                            withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
+                                sh "gren release --token=${TOKEN}"
                             }
 
-                            //git tag
-                            container('git') {
-                                ciTagGitRelease(env.RELEASE_TAG)
-                            }
-
-                            container('gren') {
-                                withCredentials([string(credentialsId: 'GITHUB_TOKEN', variable: 'TOKEN')]) {
-                                    sh "gren release --token=${TOKEN}"
-                                }
-
-                            }
                         }
                     }
-
-                    catch(err) {
-                        container('helm') {
-                            k8sDeleteBeta(params.project)
-                        }
-                    }
-
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -134,7 +134,7 @@ spec:
                 script {
                     timeout(time: 10, unit: 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
-                        sh "DEPLOYED TO UAT"
+                        echo "DEPLOYED TO UAT"
                         sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT} -m \"Message here\""
                     }
                 }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -138,7 +138,7 @@ spec:
                         echo "DEPLOYED TO UAT"
 
                         sh """ git config --global user.email "tigran@mna.com" """
-                        git """config --global user.name "Tigran Mna" """
+                        sh """ git config --global user.name "Tigran Mna" """
 
                         sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT} -m \"Message here\""
                         sh "git push --tags origin master"

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -120,7 +120,9 @@ spec:
             steps {
                 script {
                     container("git") {
-                        env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
+                        ciWithGitKey('TM_RSA') {
+                            env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
+                        }
                     }
 
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
@@ -133,7 +135,9 @@ spec:
 
                         //git tag
                         container('git') {
-                            ciTagGitRelease(env.RELEASE_TAG)
+                            ciWithGitKey('TM_RSA') {
+                                ciTagGitRelease(env.RELEASE_TAG)
+                            }
                         }
 
                         container('gren') {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -140,6 +140,7 @@ spec:
             post {
                 failure {
                     k8sDeleteBeta(params.project)
+                    currentBuild.result = 'SUCCESS'
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -100,7 +100,7 @@ spec:
                 }
 
                 container("golang") {
-                    k8sFuncTestGolang(params.project, params.domain)
+                    ciK8sFuncTestGolang(params.project, params.domain)
                 }
             }
 
@@ -125,18 +125,22 @@ spec:
             steps {
                 script {
                     try {
+
+                        //agree on release tag
+                        env.RELEASE_TAG = ciSuggestVersion(ciVersionRead())
+
                         timeout(time: 2, unit: 'MINUTES') {
                             input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
 
-                            //better docker tag
+                            //docker tag
                             container('docker') {
-                                ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", ciVersionRead() ])
+                                ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", env.RELEASE_TAG ])
                             }
 
-                            //tag git
+                            //git tag
                             container('git') {
-                                tagGitRelease(ciVersionRead())
+                                tagGitRelease(env.RELEASE_TAG)
                             }
                         }
                     }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -82,6 +82,7 @@ spec:
                 container('git') {
                     script {
                         env.BUILD_TAG = ciVersionRead()
+                        echo "build tag set to: ${env.BUILD_TAG}"
                     }
                 }
                 container('docker') {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -112,7 +112,7 @@ spec:
             }
         }
 
-        stage ("latest master tag") {
+        stage ("latest master tags") {
             when {
                 branch "master"
             }
@@ -120,6 +120,35 @@ spec:
             steps {
                 container('docker') {
                     ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}"])
+                }
+            }
+        }
+
+        stage ("latest master tags") {
+            when {
+                branch "master"
+            }
+
+            steps {
+                container('docker') {
+                    ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}"])
+                }
+            }
+        }
+
+
+        stage ("deploy/no-deploy") {
+            when {
+                branch "master"
+            }
+
+            steps {
+                script {
+                    timeout(time: 10, unit: 'MINUTES') {
+                        input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+
+                        sh "DEPLOYED TO UAT"
+                    }
                 }
             }
         }
@@ -139,12 +168,14 @@ spec:
                     try {
                         // change to a convenient timeout for you
                         timeout(time: 1, unit: 'MINUTES') {
-                            input message: "Keep deployment alive ?"
-                            echo "remember to delete resources"
+                            input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
+                            echo "remember to delete resources "
                             echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
                         }
                     } catch(err) {
-                        k8sDeleteBeta(params.project)
+                        container('helm') {
+                            k8sDeleteBeta(params.project)
+                        }
                     }
                 }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -131,7 +131,7 @@ spec:
                             ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", ciVersionRead() ])
                         }
 
-                        tagGitRelease(env.BUILD_TAG)
+                        tagGitRelease(ciVersionRead())
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -129,7 +129,9 @@ spec:
                         // better to autodelete the deployment when it times out
                         ciDeleteAfterTimingOut(2, 'MINUTES') {
 
-                            ciConditionalInputExecution("Deploy Gate", "Deploy ${params.project} to UAT?", "ok", "deploy2uat") {
+                            ciConditionalInputExecution("Deploy Gate",
+                                    "Deploy ${params.project} to UAT?",
+                                    "ok", "deploy2uat") {
                                 //todo deployment code missing
 
                                 //docker tag
@@ -178,7 +180,10 @@ spec:
                         // later it should be deleted manually, or with PR merge hook
                         ciDeleteAfterTimingOut(1, 'MINUTES') {
 
-                            ciConditionalInputExecution("delete feature", "delete feature deployment?", "continue", "delete deployment") {
+                            ciConditionalInputExecution("delete feature",
+                                    "delete feature deployment?",
+                                    "continue",
+                                    "delete deployment") {
                                 ciK8sDeleteBeta(params.project)
                             }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -101,7 +101,7 @@ spec:
             post {
                 failure {
                     container("helm") {
-                        k8sDeleteBeta(params.project)
+                        ciK8sDeleteBeta(params.project)
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -67,8 +67,13 @@ spec:
             steps {
                 script {
                     //https://issues.jenkins-ci.org/browse/JENKINS-52623 i found issue and waiting it to be fixed, i think carlos is on it now
-                    env.GIT_COMMIT = sh (script: """ git rev-parse HEAD """, returnStdout: true).trim()
-                    env.shortGitCommit = "${env.GIT_COMMIT[0..10]}"
+                    container('git') {
+                        env.GIT_COMMIT = sh (script: """ git rev-parse HEAD """, returnStdout: true).trim()
+                        env.shortGitCommit = "${env.GIT_COMMIT[0..10]}"
+                        env.BUILD_TAG = ciBuildVersionRead()
+                        echo "build tag set to: ${env.BUILD_TAG}"
+                    }
+
                     currentBuild.displayName = new SimpleDateFormat("yy.MM.dd").format(new Date()) + "-" + env.BUILD_NUMBER
                 }
             }
@@ -77,13 +82,8 @@ spec:
 
         stage('build') {
             steps {
-                container('git') {
-                    script {
-                        env.BUILD_TAG = ciBuildVersionRead()
-                        echo "build tag set to: ${env.BUILD_TAG}"
-                    }
-                }
                 container('docker') {
+                    //for feature branch
                     ciK8sBuildImage(params.image, false, env.BUILD_TAG)
                 }
             }
@@ -124,15 +124,29 @@ spec:
 
             steps {
                 script {
-                    timeout(time: 10, unit: 'MINUTES') {
-                        input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
+                    try {
+                        timeout(time: 2, unit: 'MINUTES') {
+                            input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
-                        container('docker') {
-                            ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", ciVersionRead() ])
+
+                            //better docker tag
+                            container('docker') {
+                                ciRetag(env.BUILD_TAG, false, ["latest", "${env.shortGitCommit}", ciVersionRead() ])
+                            }
+
+                            //tag git
+                            container('git') {
+                                tagGitRelease(ciVersionRead())
+                            }
                         }
-
-                        tagGitRelease(ciVersionRead())
                     }
+
+                    catch(err) {
+                        container('helm') {
+                            k8sDeleteBeta(params.project)
+                        }
+                    }
+
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -134,19 +134,7 @@ spec:
                 script {
                     timeout(time: 10, unit: 'MINUTES') {
                         input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
-                        withCredentials([sshUserPrivateKey(credentialsId: 'TM_RSA', keyFileVariable: 'SSH_KEY')]) {
-                            sh 'echo ssh -i $SSH_KEY -l git -o StrictHostKeyChecking=no \\"\\$@\\" > local_ssh.sh'
-                            sh 'chmod +x local_ssh.sh'
-                            withEnv(['GIT_SSH=local_ssh.sh']) {
-
-                                //ugly, but could not make it work globally... jenkins sometimes makes me hate my life
-                                sh """ git config --global user.email "tigran@mna.com" """
-                                sh """ git config --global user.name "Tigran Mna" """
-
-                                sh "git tag -a ${env.BUILD_TAG} ${env.GIT_COMMIT}"
-                                sh "git push origin ${env.BUILD_TAG} "
-                            }
-                        }
+                        tagGitRelease(env.BUILD_TAG)
                     }
                 }
             }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -46,6 +46,15 @@ spec:
         }
     }
 
+    parameters {
+        string(name: 'project', defaultValue: 'go-demo-4')
+        string(name: 'image', defaultValue: 'digitalinside/go-demo-4')
+        string(name: 'domain', defaultValue: '10.217.32.221.nip.io')
+        string(name: 'addr', defaultValue: 'go-demo-4.10.217.32.221.nip.io')
+        string(name: 'cmAddr', defaultValue: 'cm.4.10.217.32.221.nip.io')
+        string(name: 'chartVer', defaultValue: '0.0.1')
+    }
+
     options {
         timeout(time: 45, unit: 'MINUTES')
     }
@@ -71,7 +80,7 @@ spec:
         stage('build') {
             steps {
                 container('docker') {
-                    ciK8sBuildImage(props.image)
+                    ciK8sBuildImage(params.image)
                 }
             }
         }

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -96,13 +96,11 @@ spec:
                 }
 
                 container("kubectl") {
-                    echo "rollout"
-//                    k8sRolloutBeta(params.project)
+                    k8sRolloutBeta(params.project)
                 }
 
                 container("golang") {
-                    echo "func tests"
-//                    k8sFuncTestGolang(params.project, params.domain)
+                    k8sFuncTestGolang(params.project, params.domain)
                 }
             }
 
@@ -131,20 +129,18 @@ spec:
             }
 
             steps {
-                timeout(time: 1, unit: 'MINUTES') {
-                    input message: "Keep deployment alive ?"
-                    echo "remember to delete resources"
-                }
-            }
-
-            post {
-                failure {
-                    script{
+                script {
+                    try {
+                        // change to a convenient timeout for you
+                        timeout(time: 1, unit: 'MINUTES') {
+                            input message: "Keep deployment alive ?"
+                            echo "remember to delete resources"
+                        }
+                    } catch(err) {
                         k8sDeleteBeta(params.project)
-                        currentBuild.result = 'SUCCESS'
                     }
-
                 }
+
             }
         }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -90,7 +90,7 @@ spec:
                 }
 
                 container("kubectl") {
-                    k8sRolloutBeta(params.project)
+                    ciK8sRolloutBeta(params.project)
                 }
 
                 container("golang") {

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -124,6 +124,8 @@ spec:
                         }
                     }
 
+                    // you can have your master builds running for some time until someone decides to promote it.
+                    // better to autodelete the deployment when it times out
                     ciDeleteAfterTimingOut(2, 'MINUTES') {
                         env.userInput = input(id: "Deploy Gate", message: "Deploy ${params.project}?", ok: 'Deploy')
 
@@ -162,17 +164,16 @@ spec:
 
             steps {
                 script {
-                    try {
-                        // change to a convenient timeout for you
-                        timeout(time: 1, unit: 'MINUTES') {
-                            input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
-                            echo "remember to delete resources: run the command below"
-                            echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
-                        }
-                    } catch (err) {
-                        container('helm') {
-                            k8sDeleteBeta(params.project)
-                        }
+
+                    // this will delete feature branch deployments, unless someone wants to keep it running
+                    // later it should be deleted manually, or with PR merge hook
+                    ciDeleteAfterTimingOut(2, 'MINUTES') {
+                        env.userInput = // change to a convenient timeout for you
+                                timeout(time: 1, unit: 'MINUTES') {
+                                    input(id: "Keep it", message: "Keep ${env.BRANCH_NAME} deployment?", ok: 'Keep')
+                                    echo "remember to delete resources later: run the command below"
+                                    echo "helm delete ${ciChartNameRead(params.project).toLowerCase()} --tiller-namespace ${params.project}-build --purge"
+                                }
                     }
                 }
 

--- a/CiJenkinsfile
+++ b/CiJenkinsfile
@@ -1,0 +1,79 @@
+import java.text.SimpleDateFormat
+
+
+pipeline {
+    agent {
+        kubernetes {
+            label "builder-pod-${UUID.randomUUID().toString()}"
+            defaultContainer 'jnlp'
+            yaml """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: builder-pod
+spec:
+  containers:
+  - name: helm
+    image: vfarcic/helm:2.8.2
+    command:
+    - cat
+    tty: true
+  - name: go
+    image: golang:1.10
+    command:
+    - cat
+    tty: true
+  - name: git
+    image: alpine/git
+    command:
+    - cat
+    tty: true
+  - name: docker
+    image: docker
+    command:
+    - cat
+    tty: true
+    volumeMounts:
+    - mountPath: /var/run/docker.sock
+      name: docker-sock-volume
+  volumes:
+  - name: docker-sock-volume
+    hostPath:
+      path: /var/run/docker.sock
+      type: File
+"""
+        }
+    }
+
+    options {
+        timeout(time: 45, unit: 'MINUTES')
+    }
+
+    environment {
+        GH_USER="tigran10" // Replace me
+        DH_USER="digitalinside" // Replace me
+        PROJECT="go-demo-4"
+    }
+
+    stages {
+        stage("prep") {
+            steps {
+                script {
+                    env.GIT_COMMIT = sh (script: """ git rev-parse HEAD """, returnStdout: true).trim()
+                    env.shortGitCommit = "${env.GIT_COMMIT[0..10]}"
+                    currentBuild.displayName = new SimpleDateFormat("yy.MM.dd").format(new Date()) + "-" + env.BUILD_NUMBER
+                }
+            }
+        }
+
+
+        stage('build') {
+            steps {
+                container('docker') {
+                    k8sBuildImageBeta(props.image)
+                }
+            }
+        }
+    }
+}

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -67,7 +67,7 @@ spec:
                     sh """helm upgrade go-demo-3 \
                             --version ${env.projectVersion} \
                             --tiller-namespace ${project}-build \
-                            --namespace ${namespace} \
+                            --namespace ${env.environment} \
                             --set ingress.host=${getAddr()} \
                             --reuse-values"""
 

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -16,8 +16,8 @@ spec:
     command:
     - cat
     tty: true
-  - name: git
-    image: alpine/git
+  - name: jq
+    image: gempesaw/curl-jq 
     command:
     - cat
     tty: true
@@ -43,52 +43,108 @@ spec:
 
         stage('Project') {
             steps {
-                script {
-                    def projectChoices = map.keySet().collect()
-                    projectChoices.each {
-                        releaseScopeChoices += it + '\n'
-                    }
-
-                    def project = choice(name: 'PROJECT', choices: ${projectChoices}, description: 'What service to deploy?')
-                }
+                showProject()
             }
         }
 
         stage("Version") {
             steps {
-                container("helm") {
-                    script {
-                        projectVersions = sh(script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """, returnStdout: true).trim()
-                        def projectVersion = choice(name: 'PROJECT_VERSION', choices: ${projectVersions}, description: 'What version ?')
-                    }
-
+                container ("jq") {
+                    showVersion()
                 }
             }
         }
 
 
-        stage("Environement") {
+        stage("Environment") {
+            steps {
+                showEnvironment()
+            }
+
+        }
+
+        stage("Deploy") {
             steps {
                 container("helm") {
-                    ciK8sUpgrade(project, params.uatAddr, "${project}-uat", projectVersion)
+                    ciK8sUpgrade(env.project, getAddr(), env.environment, env.projectVersion)
                 }
                 container("kubectl") {
-                    ciK8sRollout(project, "${project}-uat")
+                    ciK8sRollout(env.project, env.environment)
                 }
             }
+        }
 
+        stage("Test") {
+            steps {
+                container("golang") {
+                    k8sProdTestGolang(getAddr())
+                }
+            }
         }
     }
-
 
 }
 
 
-def projects = ["go-demo-3":
-                        [ envs: [ build: "go-demo-3-build",
-                                  uat: "go-demo-uat",
-                                  prod: "go-demo-3-prod"
-                        ]
-                        ]
-]
+def getAddr() {
+    getEnvByName(env.project, env.environment).addr
+}
 
+def getProjectByName(n) {
+    def dpl = readYaml file: 'platform_deployment.yml'
+    for (s in dpl.services) {
+        if (s.name == n) {
+            println s
+            return s
+        }
+    }
+}
+
+def getEnvByName(project, envName) {
+    println project
+    println envName
+    for (e in getProjectByName(project).envs) {
+        println e
+        if (e.name == envName) {
+            return e
+        }
+    }
+}
+
+def showProject() {
+    def deployment = readYaml file: "platform_deployment.yml"
+    def projectChoices = ''
+    deployment.services.each {
+        projectChoices += it.name + '\n'
+    }
+
+    env.project = input( id: 'projectInput',
+            message: 'Choose properties file',
+            parameters: [ [$class: 'ChoiceParameterDefinition',
+                           choices: projectChoices,
+                           description: 'What service to deploy?',
+                           name: 'project'] ])
+}
+
+def showVersion() {
+    def projectVersions = sh(
+            script: """  curl  https://api.github.com/repos/tigran10/${env.project}/releases | jq -r ".[].tag_name" """,
+            returnStdout: true).trim()
+
+    env.projectVersion = input( id: 'versionInput',
+            message: 'Choose version',
+            parameters: [ [$class: 'ChoiceParameterDefinition',
+                           choices: projectVersions,
+                           description: 'What version to deploy?',
+                           name: 'version'] ])
+}
+
+def showEnvironment() {
+    def envs = getProjectByName(env.project).envs.name
+    env.environment = input( id: 'envInput',
+            message: 'Choose environment',
+            parameters: [ [$class: 'ChoiceParameterDefinition',
+                           choices: envs,
+                           description: 'Where to deploy?',
+                           name: 'env'] ])
+}

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -66,7 +66,14 @@ spec:
         stage("Deploy") {
             steps {
                 container("helm") {
-                    ciK8sUpgrade(env.project, getAddr(), env.environment, env.projectVersion)
+
+                    sh """helm upgrade go-demo-3 \
+                            --version ${env.projectVersion} \
+                            --tiller-namespace ${project}-build \
+                            --namespace ${namespace} \
+                            --set ingress.host=${getAddr()} \
+                            --reuse-values"""
+
                 }
                 container("kubectl") {
                     ciK8sRollout(env.project, env.environment)
@@ -77,7 +84,8 @@ spec:
         stage("Test") {
             steps {
                 container("golang") {
-                    k8sProdTestGolang(getAddr())
+//                    k8sProdTestGolang(getAddr())
+                    echo "test"
                 }
             }
         }

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -1,0 +1,91 @@
+pipeline {
+    agent {
+        kubernetes {
+            label "builder-pod-${UUID.randomUUID().toString()}"
+            defaultContainer 'jnlp'
+            yaml """
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    some-label: builder-pod
+spec:
+  containers:
+  - name: helm
+    image: vfarcic/helm:2.8.2
+    command:
+    - cat
+    tty: true
+  - name: git
+    image: alpine/git
+    command:
+    - cat
+    tty: true
+  - name: kubectl
+    image: vfarcic/kubectl
+    command: ["cat"]
+    tty: true
+"""
+        }
+    }
+
+    environment {
+        uatAddr = "uat.go-demo-3.10.64.108.181.nip.io"
+    }
+
+
+    options {
+        disableConcurrentBuilds()
+        timeout(time: 45, unit: 'MINUTES')
+    }
+
+    stages {
+
+        stage('Project') {
+            steps {
+                script {
+                    def projectChoices = map.keySet().collect()
+                    projectChoices.each {
+                        releaseScopeChoices += it + '\n'
+                    }
+
+                    def project = choice(name: 'PROJECT', choices: ${projectChoices}, description: 'What service to deploy?')
+                }
+            }
+        }
+
+        stage("Version") {
+            steps {
+                container("helm") {
+                    projectVersions = sh(script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """, returnStdout: true).trim()
+                    def projectVersion = choice(name: 'PROJECT_VERSION', choices: ${projectVersions}, description: 'What version ?')
+                }
+            }
+        }
+
+
+        stage("Environement") {
+            steps {
+                container("helm") {
+                    ciK8sUpgrade(project, params.uatAddr, "${project}-uat", projectVersion)
+                }
+                container("kubectl") {
+                    ciK8sRollout(project, "${project}-uat")
+                }
+            }
+
+        }
+    }
+
+
+}
+
+
+def projects = ["go-demo-3":
+                    [ envs: [ build: "go-demo-3-build",
+                              uat: "go-demo-uat",
+                              prod: "go-demo-3-prod"
+                             ]
+                    ]
+]
+

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
   - name: helm
-    image: vfarcic/helm:2.8.2
+    image: vfarcic/helm:2.9.1
     command:
     - cat
     tty: true
@@ -29,7 +29,9 @@ spec:
         }
     }
 
-
+    parameters {
+        string(name: 'cmAddr', defaultValue: 'cm.192.168.0.10.nip.io')
+    }
 
     options {
         disableConcurrentBuilds()
@@ -46,7 +48,7 @@ spec:
 
         stage("Version") {
             steps {
-                container ("jq") {
+                container("jq") {
                     showVersion()
                 }
             }
@@ -63,15 +65,10 @@ spec:
         stage("Deploy") {
             steps {
                 container("helm") {
-
-                    sh """helm upgrade go-demo-3 \
-                            --version ${env.projectVersion} \
-                            --tiller-namespace ${project}-build \
-                            --namespace ${env.environment} \
-                            --set ingress.host=${getAddr()} \
-                            --reuse-values"""
-
+                    addChartmuseum()
+                    installChart()
                 }
+
                 container("kubectl") {
                     ciK8sRollout(env.project, env.environment)
                 }
@@ -90,6 +87,27 @@ spec:
 
 }
 
+
+def installChart() {
+    sh """helm install chartmuseum/${env.project} \
+                            --version ${env.projectVersion} \
+                            --tiller-namespace ${project}-build \
+                            --namespace ${env.environment} \
+                            --set ingress.host=${getAddr()} """
+}
+
+def addChartmuseum() {
+    withCredentials([usernamePassword(
+            credentialsId: "chartmuseum",
+            usernameVariable: "USER", passwordVariable: "PASS")]) {
+
+        sh """helm repo add chartmuseum \
+                                http://${params.cmAddr} \
+                                --username ${USER} \
+                                --password ${PASS}
+                           """
+    }
+}
 
 def getAddr() {
     getEnvByName(env.project, env.environment).addr
@@ -119,12 +137,12 @@ def showProject() {
         projectChoices += it.name + '\n'
     }
 
-    env.project = input( id: 'projectInput',
+    env.project = input(id: 'projectInput',
             message: 'Choose properties file',
-            parameters: [ [$class: 'ChoiceParameterDefinition',
-                           choices: projectChoices,
-                           description: 'What service to deploy?',
-                           name: 'project'] ])
+            parameters: [[$class     : 'ChoiceParameterDefinition',
+                          choices    : projectChoices,
+                          description: 'What service to deploy?',
+                          name       : 'project']])
 }
 
 def showVersion() {
@@ -132,20 +150,20 @@ def showVersion() {
             script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """,
             returnStdout: true).trim()
 
-    env.projectVersion = input( id: 'versionInput',
+    env.projectVersion = input(id: 'versionInput',
             message: 'Choose version',
-            parameters: [ [$class: 'ChoiceParameterDefinition',
-                           choices: projectVersions,
-                           description: 'What version to deploy?',
-                           name: 'version'] ])
+            parameters: [[$class     : 'ChoiceParameterDefinition',
+                          choices    : projectVersions,
+                          description: 'What version to deploy?',
+                          name       : 'version']])
 }
 
 def showEnvironment() {
     def envs = getProjectByName(env.project).envs.name
-    env.environment = input( id: 'envInput',
+    env.environment = input(id: 'envInput',
             message: 'Choose environment',
-            parameters: [ [$class: 'ChoiceParameterDefinition',
-                           choices: envs,
-                           description: 'Where to deploy?',
-                           name: 'env'] ])
+            parameters: [[$class     : 'ChoiceParameterDefinition',
+                          choices    : envs,
+                          description: 'Where to deploy?',
+                          name       : 'env']])
 }

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -99,17 +99,13 @@ def getProjectByName(n) {
     def dpl = readYaml file: 'platform_deployment.yml'
     for (s in dpl.services) {
         if (s.name == n) {
-            println s
             return s
         }
     }
 }
 
 def getEnvByName(project, envName) {
-    println project
-    println envName
     for (e in getProjectByName(project).envs) {
-        println e
         if (e.name == envName) {
             return e
         }

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -147,8 +147,9 @@ def showProject() {
 
 def showVersion() {
     def projectVersions = sh(
-            script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """,
-            returnStdout: true).trim()
+    //tigran10/go-demo-4 should be changed
+    script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """,
+    returnStdout: true).trim()
 
     env.projectVersion = input(id: 'versionInput',
             message: 'Choose version',

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -57,8 +57,11 @@ spec:
         stage("Version") {
             steps {
                 container("helm") {
-                    projectVersions = sh(script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """, returnStdout: true).trim()
-                    def projectVersion = choice(name: 'PROJECT_VERSION', choices: ${projectVersions}, description: 'What version ?')
+                    script {
+                        projectVersions = sh(script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """, returnStdout: true).trim()
+                        def projectVersion = choice(name: 'PROJECT_VERSION', choices: ${projectVersions}, description: 'What version ?')
+                    }
+
                 }
             }
         }
@@ -82,10 +85,10 @@ spec:
 
 
 def projects = ["go-demo-3":
-                    [ envs: [ build: "go-demo-3-build",
-                              uat: "go-demo-uat",
-                              prod: "go-demo-3-prod"
-                             ]
-                    ]
+                        [ envs: [ build: "go-demo-3-build",
+                                  uat: "go-demo-uat",
+                                  prod: "go-demo-3-prod"
+                        ]
+                        ]
 ]
 

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -136,7 +136,7 @@ def showProject() {
 
 def showVersion() {
     def projectVersions = sh(
-            script: """  curl  https://api.github.com/repos/tigran10/${env.project}/releases | jq -r ".[].tag_name" """,
+            script: """  curl  https://api.github.com/repos/tigran10/go-demo-4/releases | jq -r ".[].tag_name" """,
             returnStdout: true).trim()
 
     env.projectVersion = input( id: 'versionInput',

--- a/DeploymentJenkinsfile
+++ b/DeploymentJenkinsfile
@@ -29,9 +29,6 @@ spec:
         }
     }
 
-    environment {
-        uatAddr = "uat.go-demo-3.10.64.108.181.nip.io"
-    }
 
 
     options {

--- a/file_for_change
+++ b/file_for_change
@@ -1,2 +1,0 @@
-cool feature
-

--- a/file_for_change
+++ b/file_for_change
@@ -1,0 +1,2 @@
+cool feature
+

--- a/helm/go-demo-3/templates/deployment.yaml
+++ b/helm/go-demo-3/templates/deployment.yaml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
       - name: api
-        image: "vfarcic/go-demo-3:{{ .Values.image.tag }}"
+        image: "digitalinside/go-demo-3:{{ .Values.image.tag }}"
         env:
         - name: DB
           value: {{ template "helm.fullname" . }}-db

--- a/k8s/uat-ns.yml
+++ b/k8s/uat-ns.yml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: go-demo-3-uat
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: build
+  namespace: go-demo-3-uat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: admin
+subjects:
+- kind: ServiceAccount
+  name: build
+  namespace: go-demo-3-build
+
+---
+
+apiVersion: v1
+kind: LimitRange
+metadata:
+  name: build
+  namespace: go-demo-3-uat
+spec:
+  limits:
+  - default:
+      memory: 200Mi
+      cpu: 0.2
+    defaultRequest:
+      memory: 100Mi
+      cpu: 0.1
+    max:
+      memory: 500Mi
+      cpu: 0.5
+    min:
+      memory: 10Mi
+      cpu: 0.05
+    type: Container
+
+---
+
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: build
+  namespace: go-demo-3-uat
+spec:
+  hard:
+    requests.cpu: 2
+    requests.memory: 3Gi
+    limits.cpu: 3
+    limits.memory: 4Gi
+    pods: 15

--- a/k8s/uat.yml
+++ b/k8s/uat.yml
@@ -1,0 +1,180 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: api
+  namespace: go-demo-3-uat
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    ingress.kubernetes.io/ssl-redirect: "false"
+    nginx.ingress.kubernetes.io/ssl-redirect: "false"
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /demo
+        backend:
+          serviceName: api
+          servicePort: 8080
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: db
+  namespace: go-demo-3-uat
+
+---
+
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: db
+  namespace: go-demo-3-uat
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["list"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: db
+  namespace: go-demo-3-uat
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: db
+subjects:
+- kind: ServiceAccount
+  name: db
+
+---
+
+apiVersion: apps/v1beta2
+kind: StatefulSet
+metadata:
+  name: db
+  namespace: go-demo-3-uat
+spec:
+  serviceName: db
+  replicas: 3
+  selector:
+    matchLabels:
+      app: db
+  template:
+    metadata:
+      labels:
+        app: db
+    spec:
+      serviceAccountName: db
+      terminationGracePeriodSeconds: 10
+      containers:
+      - name: db
+        image: mongo:3.3
+        command:
+          - mongod
+          - "--replSet"
+          - rs0
+          - "--smallfiles"
+          - "--noprealloc"
+        ports:
+          - containerPort: 27017
+        resources:
+          limits:
+            memory: "200Mi"
+            cpu: 0.2
+          requests:
+            memory: "100Mi"
+            cpu: 0.1
+        volumeMounts:
+        - name: mongo-data
+          mountPath: /data/db
+      - name: db-sidecar
+        image: cvallance/mongo-k8s-sidecar
+        env:
+        - name: MONGO_SIDECAR_POD_LABELS
+          value: "app=db"
+        - name: KUBE_NAMESPACE
+          value: go-demo-3
+        - name: KUBERNETES_MONGO_SERVICE_NAME
+          value: db
+  volumeClaimTemplates:
+  - metadata:
+      name: mongo-data
+    spec:
+      accessModes:
+      - ReadWriteOnce
+      resources:
+        requests:
+          storage: 2Gi
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: db
+  namespace: go-demo-3-uat
+spec:
+  ports:
+  - port: 27017
+  clusterIP: None
+  selector:
+    app: db
+
+---
+
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: api
+  namespace: go-demo-3-uat
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: api
+  template:
+    metadata:
+      labels:
+        app: api
+    spec:
+      containers:
+      - name: api
+        image: vfarcic/go-demo-3:latest
+        env:
+        - name: DB
+          value: db
+        readinessProbe:
+          httpGet:
+            path: /demo/hello
+            port: 8080
+          periodSeconds: 1
+        livenessProbe:
+          httpGet:
+            path: /demo/hello
+            port: 8080
+        resources:
+          limits:
+            memory: "20Mi"
+            cpu: 0.2
+          requests:
+            memory: "10Mi"
+            cpu: 0.1
+
+---
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: go-demo-3-uat
+spec:
+  ports:
+  - name: http
+    port: 8080
+  selector:
+    app: api

--- a/platform_deployment.yml
+++ b/platform_deployment.yml
@@ -1,6 +1,6 @@
 version: 1.0.0
 services:
-  - name: go-demo-3
+  - name: go-demo-4
     envs:
       - go-demo-3-uat
       - go-demo-3-prod

--- a/platform_deployment.yml
+++ b/platform_deployment.yml
@@ -1,0 +1,6 @@
+version: 1.0.0
+services:
+  - name: go-demo-3
+    envs:
+      - go-demo-3-uat
+      - go-demo-3-prod

--- a/platform_deployment.yml
+++ b/platform_deployment.yml
@@ -2,5 +2,7 @@ version: 1.0.0
 services:
   - name: go-demo-4
     envs:
-      - go-demo-3-uat
-      - go-demo-3-prod
+      - name: go-demo-3-uat
+        addr: uat.go-demo-3.192.168.0.10.nip.io
+      - name: go-demo-3-prod
+        addr: go-demo-3.192.168.0.10.nip.io

--- a/platform_deployment.yml
+++ b/platform_deployment.yml
@@ -1,6 +1,6 @@
 version: 1.0.0
 services:
-  - name: go-demo-4
+  - name: go-demo-3
     envs:
       - name: go-demo-3-uat
         addr: uat.go-demo-3.192.168.0.10.nip.io


### PR DESCRIPTION
I want some feedback, as I am getting close to finishing the code.

* Code goes up to `UAT`. We need to think how to implement another control/gate to let it go until `PROD`. Want to get a feedback first
* I have named all with prefix `ci*`, it is intentional so that i can compare myself later on changes that can be ported back to existing k8s*  functions.  As i did not want to touch them. So its just for me to compare things.
* If the code been committed to a master branch, the `minor` version will be bumped up.
* If the code been commited to a hotfix branch, the `revision` version will be bumped up.
* user will be prompted to own release version, to have a chance to bump up the `major` version if needed
* charts on `feature` branches will be deleted automatically, unless developer want to keep it running, he/she will be prompted to decide `DELETE` or `NOT` with a `timeout`.
* charts on `master` branches will be running in parallel, we need to discuss if this is good or not.
* Deployment to `UAT`, is treated as a `RELEASE` phase. It's almost the same as clicking the release button. It will deploy to UAT, test, and then do release operations.
* Release number is based on a git tag only.
* Release number is in sync between docker and git. Ex, on master It starts as `RC-1.0.0-b1` but later becomes `1.0.0` when deployed to `UAT`. Appropriate git tag will be created.
* `hotfix-*` and `master` branches are generating release candidates and can be released to UAT.
* ...and more  :) 
* Release notes are generated using [gren](https://github.com/github-tools/github-release-notes)

Lets talk :)
